### PR TITLE
本番環境でActionView::Template::Error (The asset "fried_rice" is not present in the asset pipeline.)というエラーが出ることに対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## 概要
本番環境でActionView::Template::Error (The asset "fried_rice" is not present in the asset pipeline.)というエラーが出る
これに対応するため、
https://mebee.info/2021/01/19/post-27981/
こちらの記事を参考に変更を加えた。

ref #9 
## 反省
小規模なアプリでもrails newした段階でデプロイした方が楽だったかもしれない
このエラーは別にIssueを切った方がよかったかもしれない